### PR TITLE
Cambiar "marco" por "framework"

### DIFF
--- a/01-introduction.md.erb
+++ b/01-introduction.md.erb
@@ -36,7 +36,7 @@ El resultado es una plataforma muy potente y muy sencilla ya que Meteor abstrae 
 
 Meteor permite crear una aplicación web en tiempo real en cuestión de horas. Y si ya hemos hecho desarrollo web, estaremos familiarizados con JavaScript, y ni siquiera tendremos que aprender un nuevo lenguaje.
 
-Meteor podría ser el marco ideal para nuestras necesidades, o, quizás no. Pero ¿por qué no probarlo y descubrirlo por nosotros mismos?
+Meteor podría ser el framework ideal para nuestras necesidades, o, quizás no. Pero ¿por qué no probarlo y descubrirlo por nosotros mismos?
 
 ### ¿Por qué este libro?
 


### PR DESCRIPTION
Nunca nadie ha usado la palabra `marco` para referirse a un `framework`, simplemente no pega.

Yo creo (bajo mi opinión) que una traducción debería de dejar todas aquellas palabras comunes en inglés. Sé que es un libro en castellano, pero hay palabras que no deberían de traducirse y creo que framework es una de ellas.

De hecho, dos lineas más arriba está `framework` :)
