### PR TITLE
Cambio de traducción de un párrafo

### DIFF
--- a/04-collections.md.erb
+++ b/04-collections.md.erb
@@ -51,7 +51,7 @@ El código dentro de las carpetas que no sean `client/` ni `server/` se ejecutar
 
 En el servidor, la colección tiene la tarea de hablar con la base de datos MongoDB y leer y escribir cualquier cambio. En este sentido, se puede comparar con una librería de base de datos estándar.
 
-En el cliente sin embargo, la colección es una copia de un *subconjunto* de la colección canónica real. La colección del lado del cliente mantiene, de forma constantemente y (normalmente) trasparente actualizado ese subconjunto de datos en tiempo real.
+En el cliente sin embargo, la colección es una copia de un *subconjunto* de la colección canónica real. La colección del lado del cliente se mantiene actualizada, de forma constante y (normalmente) trasparente con ese subconjunto de datos en tiempo real.
 
 <% note do %>
 


### PR DESCRIPTION
Es complicado comprobar las traducciones sin la versión original, pero he podido preguntar y conseguir ese párrafo en inglés.

La traducción actual tiene para mi 3 problemas. Uno, ese `constantemente` no es correcto en ese contexto, lo que se mantiene actualizado no es el subconjunto, es la colección, así que sería `actualizada`. Y como acabo de decir, es la colección que se mantiene actualizada **con** ese subconjunto.

Así que he cambiado la traducción por una forma algo más legible y con el significado correcto de dicho párrafo.
