### PR TITLE
Cambiar oscurecer por ocultar

### DIFF
--- a/04s-publications-and-subscriptions.md.erb
+++ b/04s-publications-and-subscriptions.md.erb
@@ -15,7 +15,7 @@ Las publicaciones y las suscripciones son dos de los conceptos más importantes 
 
 Esto ha acarreado una gran cantidad de mal entendidos, como la creencia de que Meteor es inseguro, o que las aplicaciones no pueden manejar grandes cantidades de datos.
 
-La "magia" que hace Meteor es la razón más importante de que ocurra esto al principio. Aunque la magia es, en última instancia, muy útil, puede oscurecer lo que realmente está pasando entre bastidores (como suele pasar con la magia). Así que vamos a desenvolver las capas de dicha magia para tratar de entender lo que está pasando.
+La "magia" que hace Meteor es la razón más importante de que ocurra esto al principio. Aunque la magia es en última instancia muy útil, puede ocultar lo que realmente está pasando entre bastidores (como suele pasar con la magia). Así que vamos a desenvolver las capas de dicha magia para tratar de entender lo que está pasando.
 
 ### Los viejos tiempos
 


### PR DESCRIPTION
Aunque `oscurecer` es una traducción correcta para lo que supongo que será `obscure` en inglés, es mejor decir `ocultar` que es lo realmente diríamos en castellano. Las cosas las he quitado porque realmente sobrecargan mucho la oración, pero es más personal y de tiquismiquis.

Otra cosa que me choca mucho es el "entre bastidores", traducción correcta de nuevo, pero no se me ocurre nada mejor... ¿por debajo quizá? ¿Por detrás? No sé.
