### PR TITLE
Actualizar el nombre del paquete de accounts-ui

### DIFF
--- a/06-adding-users.md.erb
+++ b/06-adding-users.md.erb
@@ -22,7 +22,7 @@ En la mayoría de los frameworks web, agregar cuentas de usuario es un problema 
 
 Por suerte, Meteor nos ampara. Gracias a la forma en la que los paquetes Meteor pueden contribuir al código del servidor (JavaScript) y al del cliente (JavaScript, HTML y CSS), podemos obtener un sistema de cuentas casi sin esfuerzo.
 
-Podríamos usar el paquete para cuentas de usuario (`meteor add accounts-ui`), pero como hemos construido toda nuestra aplicación con Bootstrap, vamos a utilizar `accounts-ui-bootstrap-dropdown` (la única diferencia es el estilo). En la línea de comandos, tecleamos:
+Podríamos usar el paquete para cuentas de usuario (`meteor add accounts-ui`), pero como hemos construido toda nuestra aplicación con Bootstrap, vamos a utilizar `ian:accounts-ui-bootstrap-3` (la única diferencia es el estilo). En la línea de comandos, tecleamos:
 
 ~~~bash
 meteor add ian:accounts-ui-bootstrap-3


### PR DESCRIPTION
Al parecer en una revisión del libro (según veo en la web) se cambió de versión para el tema de `accounts-ui` del `dropdown` al de `ian` y bueno, ese cambio no estaba reflejado en el texto.

Parece que esta traducción es la más actualizada con respecto a las otras, ¿no? Las otras siguen usando `dropdown`.

¿Es también la 1.7.1 la última del libro original? Voy a tener que pillarlo al final para poder comprobar mejor las traducciones.
