### PR TITLE
Meter parte que falta del update 1.7.1

### DIFF
--- a/14s-going-further.md.erb
+++ b/14s-going-further.md.erb
@@ -38,6 +38,10 @@ Una de las mejores formas de mantenerse al día con Meteor es suscribirse al bol
 
 [Meteorpedia](http://www.meteorpedia.com/) es un wiki sobre Meteor. Y, por supuesto, ¡está hecho con Meteor!
 
+### BulletProof Meteor
+
+Otra iniciativa del MeteorHacks de Arunoda. [BulletProof Meteor](https://bulletproofmeteor.com/) te guiará a través de un puñado de lecciones de Meteor centradas en el rendimiento, permitiéndote probar tus conocimientos paso a paso por medio de un formato de preguntas y respuestas.
+
 ### El Podcast Meteor
 
 Josh y Ry de la empresa [differential](http://differential.io) graban el [Podcast Meteor](http://www.meteorpodcast.com/) todas las semanas, otra forma de mantenerse al día con lo que pasa en la comunidad Meteor.
@@ -55,4 +59,3 @@ Si encuentras algún obstáculo, el mejor lugar para preguntar es [Stack Overflo
 ### La comunidad
 
 Por último, la mejor forma de estar al día con Meteor es mantenerse activo en la comunidad. Nosotros recomendamos inscribirse en la [lista de correo](https://www.meteor.com/) de Meteor, seguir los grupos de Google [Meteor Core](https://groups.google.com/forum/#!forum/meteor-core) y [Meteor Talk](https://groups.google.com/forum/#!forum/meteor-talk) y crear una cuenta en el foro de Meteor [Crater.io](http://crater.io/).
-

--- a/b-changelog.md.erb
+++ b/b-changelog.md.erb
@@ -18,6 +18,7 @@ Various fixes.
 - Change “router” to “route” in Pagination chapter.
 - Removed mentions of `Router.map()` in Comments and Pagination chapters.
 - Linking to Boostrap site in Adding Users chapter. 
+- Added BulletProof Meteor to Going Further chapter.
 
 ### October 28, 2014 <span class="marker version-marker">1.7</span>
 


### PR DESCRIPTION
He visto que en la versión 1.7.1 faltaba algo extra en ese capítulo y lo he traducido.

No lo añado directamente porque no sé si hay que hacer algo especial para las actualizaciones.

Así que @vicnala o @p4bloch echadle un ojo y si está todo bien metedlo para dentro.

Imagino que para sacar actualizaciones para el tutorial en si habrá que usar el Static, pero sinceramente ahora mismo no me veo con fé para hacer nada potencialmente destructivo.

Si no os cuesta mucho, meter los cambios a la versión live y yo iré metiendo todas las correcciones que pueda conforme vaya leyendo el libro y también aplicaré todos los cambios de la versión 1.7.2 cuando termine.